### PR TITLE
[feat] add 🎲 Random from Party island option

### DIFF
--- a/lib/common/python/database.py
+++ b/lib/common/python/database.py
@@ -113,6 +113,8 @@ class Lobby(BaseModel):
   creator: Player
   game: Game
   island: Optional[Island] = None
+  randomize_island: Optional[bool] = False
+  random_island: Optional[Island] = None
   status: str
   players: list[Player]
   player_count: Optional[int] = None
@@ -178,6 +180,11 @@ class Lobby(BaseModel):
 
   def randomize_players(self):
     random.shuffle(self.players)
+    self.update()
+
+  def pick_random_island(self):
+    players_with_islands = [player for player in self.players if player.island]
+    self.random_island = random.choice(players_with_islands).island
     self.update()
 
   def get_party_list(
@@ -262,7 +269,7 @@ def get_lobby_creation_eligibility(player: Player, game: Game, island: Island) -
       )
     }
 
-  if game.game_type == 'Visit Train' and not player.island:
+  if not player.island:
     return {
       'eligibility': False,
       'error_message': get_lobby_error_message(

--- a/lib/common/python/discord.py
+++ b/lib/common/python/discord.py
@@ -88,9 +88,14 @@ def bot_lobby_response(interaction: Interaction, lobby: Lobby):
   content = f'A new **{lobby.game.game_type}** lobby has been created'
   if lobby.island:
     content += f' for **{lobby.island.name}**!'
+  if lobby.pick_random_island:
+    content += ' for a 🎲 random island from the party!'
   content += '\n**Players in lobby:** '
   content += f'({lobby.player_count}/{lobby.game.min_players})'
-  content += lobby.get_party_list(numbered=False, include_island=False)
+  if lobby.randomize_island:
+    content += lobby.get_party_list(numbered=False, include_island=True)
+  else:
+    content += lobby.get_party_list(numbered=False, include_island=False)
   content += '\n**Lobby status:**\n```diff\n+ OPEN\n```'
   json = {
     'content': content,
@@ -129,13 +134,18 @@ def bot_lobby_response(interaction: Interaction, lobby: Lobby):
       reply_response.raise_for_status()
 
 def bot_party_notification(lobby: Lobby):
+  dice = ''
+  island = lobby.island
+  if lobby.pick_random_island:
+    island = lobby.random_island
+    dice = '🎲 '
   if lobby.game.game_type == 'Visit Train':
     starting_island = lobby.players[0].island
     button_label = '🏝️ Join Starting Island 🏝️'
     button_url = starting_island.url
   else:
-    button_label = f'🏝️ Join {lobby.island.name} 🏝️'
-    button_url = lobby.island.url
+    button_label = f'🏝️ Join {island.name} 🏝️'
+    button_url = island.url
   components = [
     {
       'type': 1,
@@ -155,7 +165,7 @@ def bot_party_notification(lobby: Lobby):
     content += '\n**🚆 Stops:**'
     content += lobby.get_party_list(numbered=True, include_island=True)
   else:
-    content += f'\nIsland: **{lobby.island.name}**!'
+    content += f'\n{dice}Island: **{island.name}**!'
     content += '\n**Party:**'
     content += lobby.get_party_list(numbered=False, include_island=False)
   json = {

--- a/lib/functions/discord_bot/main.py
+++ b/lib/functions/discord_bot/main.py
@@ -89,6 +89,8 @@ def handler(request):
         if lobby.player_count >= lobby.game.min_players:
           if lobby.game.game_type == 'Visit Train':
             lobby.randomize_players()
+          if lobby.randomize_island:
+            lobby.pick_random_island()
           lobby.close()
           bot_party_notification(lobby=lobby)
           return "OK", 200

--- a/lib/functions/discord_bot/subcommand.py
+++ b/lib/functions/discord_bot/subcommand.py
@@ -123,7 +123,7 @@ class Subcommand(BaseModel):
 def handle_subcommand(subcommand: Subcommand, player: Player):
   if subcommand.subcommand_group == 'create':
     island = None
-    if subcommand.island_id:
+    if subcommand.island_id and subcommand.island_id != 'random':
       island = Island(id=subcommand.island_id)
       island.get_url()
 
@@ -151,6 +151,7 @@ def handle_subcommand(subcommand: Subcommand, player: Player):
       id=subcommand.interaction.message_id,
       channel_id=subcommand.interaction.channel.id,
       creation_time=now_iso_str(),
+      randomize_island=subcommand.island_id == 'random',
       creator=player,
       game=game,
       island=island,

--- a/lib/functions/update_commands/main.py
+++ b/lib/functions/update_commands/main.py
@@ -33,6 +33,8 @@ def create_island_choices(game_type):
     for game in island.games:
       if game.game_type == game_type and game.is_featured:
         choices.append({"name": island.name, "value": island.id})
+  if choices and game_type != 'Zombies':
+    choices.insert(0, {"name": "🎲 Random from Party", "value": "random"})
   return choices
 
 def create_player_count_choices(min_players, max_players, step):


### PR DESCRIPTION
- adds "🎲 Random from Party" option when creating lobbies for non-Zombie and non-Visit Train type games. This will randomly pick an island from the party members who have set their island.
- adds requirement of setting island before creating any lobby (previously was just for Visit Train type)