### PR TITLE
[feat] adds autocomplete and new islands

### DIFF
--- a/lib/common/configs/islands.yaml
+++ b/lib/common/configs/islands.yaml
@@ -1,27 +1,29 @@
-- id: 'ef023e57-2e5f-40af-b826-aa23f430e3b7'
-  name: 'Liquidity Pool'
-  games:
-    - game_type: 'FFA DM'
-      is_featured: true
-    - game_type: 'CTF'
-      is_featured: true
-    - game_type: 'Spy Hunt'
-      is_featured: true
-- id: '51fb649f-e1fb-45f0-9de0-ec5aa041bbb4'
-  name: 'Tangos Wild West'
-  games:
-    - game_type: 'FFA DM'
-      is_featured: true
-    - game_type: 'CTF'
-      is_featured: true
-    - game_type: 'Spy Hunt'
-      is_featured: true
-- id: 'dc238f42-0aaa-4a5d-81d7-3e834c493a29'
-  name: 'Zombie Island'
-  games:
-    - game_type: 'Zombies'
-      is_featured: true
-    - game_type: 'FFA DM'
-      is_featured: true
-    - game_type: 'Spy Hunt'
-      is_featured: false
+dev:
+  islands:
+    - id: 'ef023e57-2e5f-40af-b826-aa23f430e3b7'
+      name: 'Liquidity Pool'
+port_tango:
+  islands:
+    - id: '0aa1e433-8d8c-40ad-8e06-79865e794ad2'
+      name: 'Moon Base Tango'
+    - id: '51fb649f-e1fb-45f0-9de0-ec5aa041bbb4'
+      name: 'Tangos Wild West'
+    - id: '7a3821ca-8e2d-4bb1-8483-d6491f66f94a'
+      name: 'Tangos Tree Fort 50K'
+integrators:
+  - name: 'Bloom Brigade'
+    islands:
+      - id: '5bbd915c-374e-480a-a430-d536a7912470'
+        name: 'Frens Gaming'
+      - id: '7e14bbc6-fd81-4350-ade6-1d993be39c20'
+        name: 'Kandy Land'
+      - id: 'bf5a68dc-daaa-4d67-80ab-5cad9521a16e'
+        name: '25 Bloom Bonsai'
+  - name: 'Mars Cat Voyage'
+    islands:
+      - id: '0be6e5e4-206b-4cd4-a5b6-0d17a7880078'
+        name: 'Sloths Mansion'
+      - id: 'ef239a61-bba3-453a-989b-73a49b90f688'
+        name: 'Win at Willies'
+      - id: 'f30985d3-534a-4466-81b8-62ac4d87ed18'
+        name: "Biggunn's Arena"

--- a/lib/common/python/discord.py
+++ b/lib/common/python/discord.py
@@ -24,11 +24,6 @@ headers = {
   'Content-Type': 'application/json'
 }
 
-class RequestType(Enum):
-  PING = 1
-  APPLICATION_COMMAND = 2
-  MESSAGE_COMPONENT = 3
-
 class DiscordErrorType(Enum):
   INVALID_SIGNATURE = 'Invalid signature'
   COMMAND_IN_THREAD = 'Command was used in a thread'

--- a/lib/functions/discord_bot/island_choices.py
+++ b/lib/functions/discord_bot/island_choices.py
@@ -1,0 +1,44 @@
+import random
+import copy
+import yaml
+
+with open('islands.yaml', 'r', encoding='utf-8') as file:
+  islands_config = yaml.safe_load(file)
+
+def generate_island_choices(query, config=islands_config):
+  # Make a deep copy of the configuration to avoid modifying the original
+  config_copy = copy.deepcopy(config)
+
+  # Extract and shuffle dev islands
+  dev_islands = config_copy['dev']['islands']
+  random.shuffle(dev_islands)
+
+  # Extract and shuffle Port Tango islands
+  port_tango_islands = config_copy['port_tango']['islands']
+  random.shuffle(port_tango_islands)
+
+  # Extract other integrators and shuffle their islands
+  other_integrators = config_copy['integrators']
+  for integrator in other_integrators:
+    random.shuffle(integrator['islands'])
+
+  # Randomize the order of the integrators themselves
+  random.shuffle(other_integrators)
+
+  # Initialize lists to hold the round-robin order
+  round_robin_lists = (
+    [dev_islands, port_tango_islands] +
+    [integrator['islands'] for integrator in other_integrators]
+  )
+
+  # Perform round-robin selection until all lists are exhausted
+  choices = []
+  while any(round_robin_lists):
+    for island_list in round_robin_lists:
+      if island_list:  # Check if the current list is not exhausted
+        island = island_list.pop(0)
+        choices.append({'name': island['name'], 'value': island['id']})
+  choices.insert(0, {"name": "🎲 Random from Party", "value": "random"})
+
+  filtered_choices = [choice for choice in choices if query.lower() in choice['name'].lower()]
+  return filtered_choices

--- a/lib/functions/update_commands/main.py
+++ b/lib/functions/update_commands/main.py
@@ -2,7 +2,6 @@ import os
 import yaml
 import requests
 import functions_framework
-from database import Island
 
 BOT_TOKEN = os.getenv('BOT_TOKEN')
 BOT_APP_ID = os.getenv('BOT_APP_ID')
@@ -14,9 +13,6 @@ headers = {
   "Content-Type": "application/json"
 }
 
-with open('islands.yaml', 'r', encoding='utf-8') as file:
-  islands_config = yaml.safe_load(file)
-
 with open('lobby_create.yaml', 'r', encoding='utf-8') as file:
   lobby_create_config = yaml.safe_load(file)
 
@@ -24,18 +20,6 @@ with open('lobby_set.yaml', 'r', encoding='utf-8') as file:
   set_subcommand_group = yaml.safe_load(file)
 
 game_modes = lobby_create_config['game_modes']
-
-islands = [Island(**island) for island in islands_config]
-
-def create_island_choices(game_type):
-  choices = []
-  for island in islands:
-    for game in island.games:
-      if game.game_type == game_type and game.is_featured:
-        choices.append({"name": island.name, "value": island.id})
-  if choices and game_type != 'Zombies':
-    choices.insert(0, {"name": "🎲 Random from Party", "value": "random"})
-  return choices
 
 def create_player_count_choices(min_players, max_players, step):
   return [{"name": str(i), "value": i} for i in range(min_players, max_players + 1, step)]
@@ -62,15 +46,23 @@ for subcommand_name, mode_info in game_modes.items():
     "description": f"Creates a matchmaking lobby for {mode_info['type']} game mode",
     "options": []
   }
-  island_choices = create_island_choices(mode_info['type'])
-  if island_choices:
-    subcommand['options'].append({
-      "name": "island",
-      "description": "The name of island where the game will be hosted",
-      "type": 3,  # 3 is for string options
-      "required": True,
-      "choices": island_choices
-    })
+  if mode_info['type'] != 'Visit Train':
+    if mode_info['type'] == 'Zombies':
+      subcommand['options'].append({
+        "name": "island",
+        "description": "The name of island where the game will be hosted",
+        "type": 3,  # 3 is for string options
+        "required": True,
+        "choices": [{'name': 'Zombie Island', 'value': 'dc238f42-0aaa-4a5d-81d7-3e834c493a29'}]
+      })
+    else:
+      subcommand['options'].append({
+        "autocomplete": True,
+        "name": "island",
+        "description": "The name of island where the game will be hosted",
+        "type": 3,  # 3 is for string options
+        "required": True
+      })
   subcommand['options'].append({
     "name": "players",
     "description": "Amount of players. Lobby will auto-close after this threshold is met",


### PR DESCRIPTION
- adds autocomplete. Island options are now dynamically served from server. Default list follows a "round robin" approach between lists of dev, Port Tango, and discord server integrators. See `lib/functions/discord_bot/island_choices.py` for logic.
- Adds islands for Bloom Brigade and Mars Cat Voyage